### PR TITLE
Strip all spaces from user-entered secret key

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,11 @@ use qrcode::QrCode;
 use std::io;
 
 fn main() {
-    let key =
-        rpassword::read_password_from_tty(Some("Enter the secret:\n")).expect("Error reading key");
+    let key: String = rpassword::read_password_from_tty(Some("Enter the secret key:\n"))
+        .expect("Error reading secret key")
+        .chars()
+        .filter(|&c| c != ' ')
+        .collect();
 
     println!("Enter name of service:");
     let service = gets().unwrap();


### PR DESCRIPTION
Sometimes secret keys are presented with spaces every four characters for readability. This change strips out any spaces entered by the user, to better ensure the resulting QR code is correct. 

We could go further and uppercase the secret key, but I'm not sure how that affects the generated QR code. 